### PR TITLE
Add font override parameters

### DIFF
--- a/3dnameplate.scad
+++ b/3dnameplate.scad
@@ -144,6 +144,12 @@ fontstyle2="<same as fontstyle1>"; //["<same as fontstyle1>","Regular","Bold","I
 fontname3="<same as fontname1>"; //["<same as fontname1>","Noto Sans CJK HK","Press Start 2P","Liberation Sans","DejaVu Serif","Ami R","Arial Rounded MT Bold","Bauhaus 93","Bell MT","Freestyle Script","Ravie"]
 fontstyle3="<same as fontstyle1>"; //["<same as fontstyle1>","Regular","Bold","Italic"]
 fontname_hiddentext="<same as fontname1>"; //["<same as fontname1>","Noto Sans CJK HK","Press Start 2P","Liberation Sans","DejaVu Serif","Ami R","Arial Rounded MT Bold","Bauhaus 93","Bell MT","Freestyle Script","Ravie"]
+
+// Optional overrides to specify any installed font family directly. When non-empty,
+// these values take precedence over the dropdown selections above.
+fontname1_override="";
+fontname2_override="";
+fontname3_override="";
 // Font used for emoji characters in special icons
 emoji_font="Noto Emoji";
 // Style for emoji font (if the selected font provides styles)
@@ -204,18 +210,19 @@ assert(tm_feature_check.size.x > 0,
            "Install a recent OpenSCAD snapshot and activate\n",
            "Edit \u2192 Preferences \u2192 Features \u2192 textmetrics"));
 
-fontname2_final = (fontname2=="<same as fontname1>" ? fontname1 : fontname2 );
-fontname3_final = (fontname3=="<same as fontname1>" ? fontname1 : fontname3 );
-fontname_hiddentext_final =(fontname_hiddentext=="<same as fontname1>"? fontname1 : fontname_hiddentext );
+fontname1_final = (fontname1_override!="" ? fontname1_override : fontname1);
+fontname2_final = (fontname2_override!="" ? fontname2_override : (fontname2=="<same as fontname1>" ? fontname1_final : fontname2));
+fontname3_final = (fontname3_override!="" ? fontname3_override : (fontname3=="<same as fontname1>" ? fontname1_final : fontname3));
+fontname_hiddentext_final = (fontname_hiddentext=="<same as fontname1>" ? fontname1_final : fontname_hiddentext);
 
 fontstyle2_final = (fontstyle2=="<same as fontstyle1>" ? fontstyle1 : fontstyle2 );
 fontstyle3_final = (fontstyle3=="<same as fontstyle1>" ? fontstyle1 : fontstyle3 );
 
-realtextsize1=textsize1*(fontname1=="Press Start 2P"?1.5:1);
-realtextsize2=textsize2*(fontname2=="Press Start 2P"?1.5:1);
-realtextsize3=textsize3*(fontname3=="Press Start 2P"?1.5:1);
+realtextsize1=textsize1*(fontname1_final=="Press Start 2P"?1.5:1);
+realtextsize2=textsize2*(fontname2_final=="Press Start 2P"?1.5:1);
+realtextsize3=textsize3*(fontname3_final=="Press Start 2P"?1.5:1);
 
-fullfont1=str(fontname1,":style=",fontstyle1);
+fullfont1=str(fontname1_final,":style=",fontstyle1);
 fullfont2=str(fontname2_final,":style=",fontstyle2_final);
 fullfont3=str(fontname3_final,":style=",fontstyle3_final);
 fullfont_hidden=str(fontname_hiddentext_final,":style=",fontstyle1);

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains an OpenSCAD script for generating customizable 3D name 
 
 Open `3dnameplate.scad` in OpenSCAD and use the Customizer pane to tweak the text, layout, and other options. The Customizer exposes settings for the three text lines, base style, sweep angle and more. Font choices can be adjusted using the `fontname*` and `fontstyle*` parameters. In the Customizer these appear under the “Hidden” section. Enter any installed font family and style to render the text. The script also provides `text_color` and `base_color` parameters so the preview can show different colors for the text and base. Specify these colors using standard 0‑255 RGB values.
 
+If you need to use a font that is not available in the drop‑down lists, provide the name via `fontname1_override`, `fontname2_override`, or `fontname3_override`. A non‑empty override parameter will replace the corresponding drop‑down selection.
+
 Emoji and special characters are supported. For the best results install a font that includes emoji characters, such as **Noto Emoji**, and set the `emoji_font` parameter to that family name if OpenSCAD does not pick it automatically. You can also specify `emoji_font_style` (e.g. `Bold`) if your chosen emoji font provides different styles. After installing a new font, restart OpenSCAD so it becomes available in the Customizer.
 
 Use the optional `special_character_y_offset` parameter to raise or lower the left and right special icons if they need slight vertical adjustment.


### PR DESCRIPTION
## Summary
- allow overriding dropdown selections with `fontname1_override`, `fontname2_override`, and `fontname3_override`
- apply overrides when building fonts
- document the feature in the README

## Testing
- `git log -1 --stat`