### PR TITLE
Fix alignment for emoji-aware text

### DIFF
--- a/3dnameplate.scad
+++ b/3dnameplate.scad
@@ -89,6 +89,13 @@ base_color = [204, 204, 204]; //[color]
 //Utility: convert 0-255 RGB values to the 0-1 range expected by color()
 function rgb255(c) = [for(i=[0:len(c)-1]) (i < 3 ? c[i]/255 : c[i])];
 
+// Determine if a character should be rendered using the emoji font
+// by checking its Unicode code point against common emoji ranges
+function is_emoji_char(ch) =
+    let(cp = ord(ch))
+        (cp >= 0x1F000 && cp <= 0x1FAFF) ||
+        (cp >= 0x2600  && cp <= 0x26FF);
+
 //-----------------
 /* [Hidden Text] */ 
 //Hidden text under the base (in case you need it), settings are way below.
@@ -246,21 +253,23 @@ specialchar_y = specialchar_y_base + special_character_y_offset;
 cutcube_x_nospecialchar=max((len(textstring1)+1)*realtextsize1,(len(textstring2)+1)*realtextsize2,(len(textstring3)+1)*realtextsize3); 
 cutcube_x=cutcube_x_nospecialchar+specialcharsize*((special_character_left=="5Star"||special_character_right=="5Star")?5:1)+distancespecialchar; 
 
-//calc width of text
-size1=textmetrics(textstring1,size=textsize1,font=fullfont1,halign=halignvalue,valign="center",spacing=letter_spacing_scale);
+//calc width of text using left alignment so we can manually position lines
+size1=textmetrics(textstring1,size=textsize1,font=fullfont1,halign="left",valign="center",spacing=letter_spacing_scale);
 //ECHO: { position = [-74.0898, -8.51968]; size = [76.6539, 17.0394]; ascent = 16.6298; descent = -0.4096; offset = [-75.7998, -8.11008]; advance = [75.7998, 0]; 
 xsize1=size1.size.x;
 xpos1=size1.position.x;
-size2=textmetrics(textstring2,size=textsize2,font=fullfont2,halign=halignvalue,valign="center",spacing=letter_spacing_scale);
+size2=textmetrics(textstring2,size=textsize2,font=fullfont2,halign="left",valign="center",spacing=letter_spacing_scale);
 xsize2=size2.size.x;
 xpos2=size2.position.x;
-size3=textmetrics(textstring3,size=textsize3,font=fullfont3,halign=halignvalue,valign="center",spacing=letter_spacing_scale);
+size3=textmetrics(textstring3,size=textsize3,font=fullfont3,halign="left",valign="center",spacing=letter_spacing_scale);
 xsize3=size3.size.x;
 xpos3=size3.position.x;
-textminx=min(xpos1,xpos2,xpos3);
 textwidth=max(xsize1,xsize2,xsize3);
 echo(textwidth);
-shifttext= -textminx-textwidth/2;
+shifttext=
+    (textalign=="center" ? -textwidth/2 :
+     (textalign=="right" ? -textwidth :
+      0));
 //(textalign=="right"?textwidth/2:
            //(textalign=="left"?-textwidth/2:
            //(textalign=="center"?0:0)));
@@ -389,8 +398,30 @@ function type(x)=
              s[0]=="[" && s[len(s)-1]=="]"
              && all( [ for(x=s2) isint(int(x)) ] )? "range"
              : "unknown"
-     )
+    )
 );
+
+// Render a text line character by character so emoji glyphs can use a
+// different font. Advance widths are computed per character using
+// textmetrics().
+module draw_text_line_with_emoji(str, size, normal_font, emoji_font)
+{
+    for(i = [0 : len(str)-1])
+    {
+        ch = str[i];
+        use_font = is_emoji_char(ch) ? emoji_font : normal_font;
+
+        x_off = (i == 0) ? 0 :
+            sum([for(j=[0:i-1]) let(prev=str[j],
+                                   pf=is_emoji_char(prev) ? emoji_font : normal_font,
+                                   m=textmetrics(prev, size=size, font=pf, spacing=1))
+                m.advance.x * letter_spacing_scale]);
+
+        translate([x_off, 0, 0])
+            text(ch, size=size, font=use_font,
+                 halign="left", valign="center", spacing=1);
+    }
+}
 
 
 
@@ -405,12 +436,12 @@ module writetext(textstr1, textstr2, textstr3, sizeit1, sizeit2, sizeit3, add_a_
         translate([shifttext,0,0])
         {
             translate([0,distance_line_2_to_3+distance_line_1_to_2,0])
-                text(textstr1,size=sizeit1,font=fullfont1,halign=halignvalue,valign="center",spacing=letter_spacing_scale);
-            
+                draw_text_line_with_emoji(textstr1, sizeit1, fullfont1, emoji_font_full);
+
             translate([0,distance_line_2_to_3,0])
-                text(textstr2,size=sizeit2,font=fullfont2,halign=halignvalue,valign="center",spacing=letter_spacing_scale);
-            
-            text(textstr3,size=sizeit3,font=fullfont3,halign=halignvalue,valign="center",spacing=letter_spacing_scale);
+                draw_text_line_with_emoji(textstr2, sizeit2, fullfont2, emoji_font_full);
+
+            draw_text_line_with_emoji(textstr3, sizeit3, fullfont3, emoji_font_full);
         }
         
         translate([ 0,specialchar_y,0])

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To widen or tighten the spacing between letters, use the `letter_spacing_scale` 
 
 If you need to use a font that is not available in the drop‑down lists, provide the name via `fontname1_override`, `fontname2_override`, or `fontname3_override`. A non‑empty override parameter will replace the corresponding drop‑down selection.
 
-Emoji and special characters are supported. For the best results install a font that includes emoji characters, such as **Noto Emoji**, and set the `emoji_font` parameter to that family name if OpenSCAD does not pick it automatically. You can also specify `emoji_font_style` (e.g. `Bold`) if your chosen emoji font provides different styles. After installing a new font, restart OpenSCAD so it becomes available in the Customizer.
+Emoji and special characters are supported. For the best results install a font that includes emoji characters, such as **Noto Emoji**, and set the `emoji_font` parameter to that family name if OpenSCAD does not pick it automatically. You can also specify `emoji_font_style` (e.g. `Bold`) if your chosen emoji font provides different styles. After installing a new font, restart OpenSCAD so it becomes available in the Customizer. Emojis mixed into the text lines are automatically rendered using the configured emoji font.
 
 Use the optional `special_character_y_offset` parameter to raise or lower the left and right special icons if they need slight vertical adjustment.
 


### PR DESCRIPTION
## Summary
- compute line widths with left alignment
- update shifttext formula so centering works with per-character rendering

## Testing
- `openscad -o /tmp/out.stl 3dnameplate.scad` *(fails: textmetrics not enabled)*