### PR TITLE
Fix RiseText module and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Hidden text can also be engraved on the underside of the plate. Set the text via
 
 When the base style is set to **Round**, the `round_base_link_thickness` parameter can add slim connectors along each text line before the base is offset. These bars help link separated letters into a single circular plate. Set it to `0` to disable the connectors.
 
+The new `global_corner_radius` parameter fillets every vertical edge of the finished plate. Set a positive value (e.g. `1`) to soften both the base outline and the letter corners.
+
 ## OpenSCAD version and `textmetrics`
 
 This script uses the `textmetrics` function, which is available in recent OpenSCAD snapshots. Install a version that includes it and enable the feature under **Edit → Preferences → Features**.


### PR DESCRIPTION
## Summary
- extract `_rise_text_core` module outside `RiseText`
- call helper from `RiseText` with optional Minkowski rounding
- remove stray calls from `_base_text_caps_core`

## Testing
- `openscad -o /tmp/out.stl 3dnameplate.scad` *(fails: textmetrics feature not enabled)*