### PR TITLE
Fix keyhole hanger orientation

### DIFF
--- a/3dnameplate.scad
+++ b/3dnameplate.scad
@@ -495,17 +495,24 @@ module draw_text_line_with_emoji(str, size, normal_font, emoji_font)
 }
 
 // 2D outline of a keyhole with a circular head and narrow slot
+// 2D outline of a keyhole with a circular head and a slot opening upward.
+// The circle center is the reference point. The slot extends in +Y so that
+// it can be positioned relative to the top edge of the base.
 module KeyholeShape(d, slot_w, slot_len) {
     circle(d = d, $fn = 32);
-    translate([0, -slot_len/2, 0])
+    translate([0, slot_len/2, 0])
         square([slot_w, slot_len], center = true);
 }
 
 // Extruded keyhole cutout including deeper pocket for the screw head
+// Extrude the narrow slot first, then carve a deeper pocket matching the
+// circle diameter so a screw head can be captured.
 module KeyholeCutout(d, slot_w, slot_len, depth, head_depth) {
+    // Narrow portion reaching the surface
     linear_extrude(height = depth)
         KeyholeShape(d, slot_w, slot_len);
-    translate([0, 0, -head_depth])
+    // Wider cavity for the screw head inside the base
+    translate([0, 0, depth - head_depth])
         linear_extrude(height = head_depth)
             KeyholeShape(d, d, slot_len);
 }

--- a/docs/keyhole_hanger_plan.md
+++ b/docs/keyhole_hanger_plan.md
@@ -32,16 +32,16 @@ but not breaking through the top edge of the base.
 ## Geometry
 
 A helper module `KeyholeShape(d, slot_w, slot_len)` will generate a 2D shape
-consisting of a circle and a downward slot. This profile describes the outline
-visible from the back of the plate. A second, slightly deeper extrusion widens
-the slot so that its internal width equals the circle diameter. This step
+consisting of a circle and an upward-pointing slot. This profile describes the
+outline visible from the back of the plate. A second, slightly deeper extrusion
+widens the slot so that its internal width equals the circle diameter. This step
 creates a cavity to capture the screw head while maintaining a narrow slot
 opening.
 
 ```
 module KeyholeShape(d, slot_w, slot_len) {
     circle(r = d/2, $fn = 32);
-    translate([0, -slot_len/2, 0])
+    translate([0, slot_len/2, 0])
         square([slot_w, slot_len], center = true);
 }
 
@@ -49,7 +49,7 @@ module KeyholeCutout(d, slot_w, slot_len, depth, head_depth) {
     // narrow slot reaching the surface
     linear_extrude(depth) KeyholeShape(d, slot_w, slot_len);
     // deeper pocket matching the hole diameter for the screw head
-    translate([0, 0, -head_depth])
+    translate([0, 0, depth - head_depth])
         linear_extrude(head_depth)
             KeyholeShape(d, d, slot_len);
 }


### PR DESCRIPTION
## Summary
- correct keyhole slot orientation to open upward
- carve head pocket inside the base
- update keyhole documentation

## Testing
- `git status --short`