### PR TITLE
Clamp keyhole depth to base thickness

### DIFF
--- a/3dnameplate.scad
+++ b/3dnameplate.scad
@@ -273,9 +273,14 @@ assert(tm_feature_check.size.x > 0,
            "Install a recent OpenSCAD snapshot and activate\n",
            "Edit \u2192 Preferences \u2192 Features \u2192 textmetrics"));
 
-// Ensure the keyhole recess does not exceed the base thickness
-assert(keyhole_depth + keyhole_head_depth + keyhole_bleed < baseheight,
-       "keyhole_depth must be less than baseheight");
+// Limit the total keyhole recess depth so it never exceeds the base thickness.
+// Users of older versions saw an assertion failure if the sum of
+// `keyhole_depth`, `keyhole_head_depth` and `keyhole_bleed` was too large.
+keyhole_depth_eff = min(keyhole_depth + keyhole_head_depth + keyhole_bleed,
+                        baseheight);
+if (keyhole_depth_eff < keyhole_depth + keyhole_head_depth + keyhole_bleed)
+    echo(str("WARNING: keyhole depth clamped to baseheight (",
+              keyhole_depth_eff, "mm)"));
 
 fontname1_final = (fontname1_override!="" ? fontname1_override : fontname1);
 fontname2_final = (fontname2_override!="" ? fontname2_override : (fontname2=="<same as fontname1>" ? fontname1_final : fontname2));
@@ -1330,7 +1335,7 @@ module BaseTextCaps(textstr1, textstr2, textstr3, textsize1, textsize2, textsize
             if (keyhole_count > 0)
                 KeyholeCutouts(keyhole_count, keyhole_spacing,
                                keyhole_diameter, keyhole_slot_width,
-                               keyhole_slot_length, keyhole_depth,
+                               keyhole_slot_length, keyhole_depth_eff,
                                keyhole_head_depth, keyhole_vertical_offset,
                                keyhole_balance_offset, keyhole_bleed);
 

--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ The goal of the project is to quickly create attractive curved or pedestal style
 
 ### Keyhole Hangers
 
-`base_text_caps` plates can include optional keyhole hangers for wall mounting. Enable them in the **Keyhole Settings** section of the customizer. Two keyholes can be spaced apart, or a single hanger can be shifted horizontally to balance the plate.
+`base_text_caps` plates can include optional keyhole hangers for wall mounting. Enable them in the **Keyhole Settings** section of the customizer. Two keyholes can be spaced apart, or a single hanger can be shifted horizontally to balance the plate. If the combined keyhole depth would exceed the base thickness, it is automatically reduced and a warning is printed during rendering.

--- a/docs/keyhole_hanger_plan.md
+++ b/docs/keyhole_hanger_plan.md
@@ -100,8 +100,8 @@ simultaneously if desired.
 
 ## Considerations
 
-- The keyhole depth should not exceed the base thickness. A simple assertion can
-  warn the user if `keyhole_depth >= baseheight`.
+- The keyhole recess depth is automatically clamped so it never exceeds the
+  base thickness. A warning is printed when this reduction occurs.
 - When only one keyhole is used, consider measuring the weight distribution of
   the final print and setting `keyhole_balance_offset` accordingly so the plate
   hangs level. The same offset is applied to two-keyhole layouts.


### PR DESCRIPTION
## Summary
- prevent assertion failure when keyhole depth exceeds base thickness
- warn and clamp keyhole depth instead
- document depth clamping behavior

## Testing
- `openscad -o /tmp/test.stl 3dnameplate.scad` *(fails: textmetrics feature not enabled)*