### PR TITLE
Add protruding keyhole supports

### DIFF
--- a/3dnameplate.scad
+++ b/3dnameplate.scad
@@ -534,6 +534,26 @@ module KeyholeCutout(d, slot_w, slot_len, depth, head_depth, bleed) {
             }
 }
 
+// Extrude the keyhole shape upward to form a hanging support
+// A tiny offset margin helps the support merge cleanly with the base
+module KeyholeSupport(d, slot_w, slot_len, baseheight, margin=0.2) {
+    linear_extrude(height = baseheight)
+        offset(delta = margin)
+            KeyholeShape(d, slot_w, slot_len);
+}
+
+// Create one or two keyhole supports positioned like the cutouts
+module KeyholeSupports(count, spacing, d, slot_w, slot_len,
+                       baseheight, vert_off, balance_off, margin=0.2) {
+    positions = (count == 2) ? [balance_off - spacing/2,
+                                balance_off + spacing/2] :
+                                (count == 1 ? [balance_off] : []);
+    y_pos = cutcube_yz/2 - vert_off;
+    for(xp = positions)
+        translate([xp, y_pos, 0])
+            KeyholeSupport(d, slot_w, slot_len, baseheight, margin);
+}
+
 // Place one or two keyholes on the back of the base
 module KeyholeCutouts(count, spacing, d, slot_w, slot_len,
                       depth, head_depth, vert_off, balance_off, bleed) {
@@ -1292,6 +1312,16 @@ module BaseTextCaps(textstr1, textstr2, textstr3, textsize1, textsize2, textsize
                 } else if(BaseType=="Bottom_Line") {
 
                 }
+
+                // Add protruding keyhole hanger support when positioned above
+                // the base. Must be part of the base geometry before any
+                // subtractive operations occur.
+                if (keyhole_count > 0 && keyhole_vertical_offset < 0)
+                    KeyholeSupports(keyhole_count, keyhole_spacing,
+                                    keyhole_diameter, keyhole_slot_width,
+                                    keyhole_slot_length, baseheight,
+                                    keyhole_vertical_offset,
+                                    keyhole_balance_offset);
 
                 // Add magnet holder walls if enabled
                 MagnetHolder(magnettype,"add");

--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ The goal of the project is to quickly create attractive curved or pedestal style
 
 ### Keyhole Hangers
 
-`base_text_caps` plates can include optional keyhole hangers for wall mounting. Enable them in the **Keyhole Settings** section of the customizer. Two keyholes can be spaced apart, or a single hanger can be shifted horizontally to balance the plate. If the combined keyhole depth would exceed the base thickness, it is automatically reduced and a warning is printed during rendering.
+`base_text_caps` plates can include optional keyhole hangers for wall mounting. Enable them in the **Keyhole Settings** section of the customizer. Two keyholes can be spaced apart, or a single hanger can be shifted horizontally to balance the plate. If the combined keyhole depth would exceed the base thickness, it is automatically reduced and a warning is printed during rendering. When the vertical offset is negative the hanger protrudes above the back surface, forming its own boundary so the full keyhole shape prints.


### PR DESCRIPTION
## Summary
- add `KeyholeSupport` and `KeyholeSupports` modules
- incorporate protruding keyhole support when keyhole offset is negative
- document new hanger behaviour in README

## Testing
- `openscad -o /tmp/test.stl 3dnameplate.scad` *(fails: textmetrics feature not enabled)*