### PR TITLE
Add emoji infill thickness parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Use the optional `special_character_y_offset` parameter to raise or lower the le
 The `emoji_size_scale` parameter adjusts the size of the left/right special characters. A separate `emoji_text_size_scale` control changes the size of emoji characters that appear inside the text lines.
 The new `emoji_text_x_offset` and `emoji_text_y_offset` parameters can shift those inline emoji left/right or up/down if needed.
 
+When `emoji_base_infill` is enabled, the script fills the area under emoji glyphs so they sit on a solid patch of the base color.  The `emoji_infill_margin` parameter controls how much the outline expands to merge nearby shapes.  Use `emoji_infill_thickness` to adjust how tall this infill extrusion is (1 mm by default).
+
 Hidden text can also be engraved on the underside of the plate. Set the text via `HiddenText` and adjust its size with `HiddenTextSize`. The new parameters `HiddenTextStyle`, `HiddenTextX`, `HiddenTextY` and `HiddenTextDepth` control the font style, position offsets and engraving depth of this secret message.
 
 When the base style is set to **Round**, the `round_base_link_thickness` parameter can add slim connectors along each text line before the base is offset. These bars help link separated letters into a single circular plate. Set it to `0` to disable the connectors.


### PR DESCRIPTION
## Summary
- expose `emoji_infill_thickness` setting
- extrude emoji infill using this new thickness
- document emoji base infill parameters

## Testing
- `openscad -o /tmp/out.stl 3dnameplate.scad` *(fails: command not found)*