### PR TITLE
Fix photoframe slot placement

### DIFF
--- a/3dnameplate.scad
+++ b/3dnameplate.scad
@@ -673,8 +673,9 @@ module PhotoFrameShape(w, h, border, thickness) {
 }
 
 // Subtractive slot for the photo opening
-// The slot is centered on the frame thickness so it can cut
-// through the frame even when only partially merged with the base.
+// This shape is used to cut a slot allowing a photo to slide in
+// from above. Position it so the top of the extrusion is flush with
+// the frame border.
 module PhotoFrameSlot(w, h, border, depth, gap) {
     inner = [w - 2*border, h - 2*border];
     slot_w = min(w, inner[0] + 2*gap);
@@ -1602,7 +1603,8 @@ module BaseTextCaps(textstr1, textstr2, textstr3, textsize1, textsize2, textsize
             // Remove the photo slot so the frame opening remains clear
             if (photoframe_enable)
                 translate([photoframe_x_offset, photoframe_y_offset,
-                          photoframe_z_offset + photoframe_thickness/2])
+                          photoframe_z_offset + photoframe_thickness -
+                              photoframe_slot_depth/2])
                     PhotoFrameSlot(photoframe_width, photoframe_height,
                                    photoframe_border, photoframe_slot_depth,
                                    photoframe_slot_margin);

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The script can optionally generate a rectangular photo frame as part of the
 plate. Enable the frame in the **Photo Frame Settings** section and specify the
 outer dimensions and border width. The frame thickness is measured from the
 bottom upward so it can be raised or recessed using the `photoframe_z_offset`
-parameter. The internal slot is centered on the frame thickness so it
-overwrites any overlapping base material. Its size is slightly larger than the
-frame opening, controlled by `photoframe_slot_margin`, allowing a printed photo
-to slide in even when the frame merges with the plate.
+parameter. The internal slot starts at the top of the frame and extends
+downward so a printed photo can slide in from above. Its size is slightly
+larger than the frame opening, controlled by `photoframe_slot_margin`, allowing
+a printed photo to slide in even when the frame merges with the plate.


### PR DESCRIPTION
## Summary
- revise docs to clarify photoframe slot orientation
- tweak PhotoFrameSlot comment
- align subtractive slot with top of photoframe

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683ec23c92b88323871d46467b3a24fb